### PR TITLE
本次新建了多个类实现了微信授权登录、支付、退款、提现功能（参考文章https://blog.csdn.net/weixin_4541110…

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
       <profile name="Maven default annotation processors profile" enabled="true">
         <sourceOutputDir name="target/generated-sources/annotations" />
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />

--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.png" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,27 @@
             <version>2.3.0</version>
         </dependency>
         <dependency>
+            <groupId>com.github.binarywang</groupId>
+            <artifactId>weixin-java-miniapp</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.binarywang</groupId>
+            <artifactId>weixin-java-pay</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.wxpay</groupId>
+            <artifactId>wxpay-sdk</artifactId>
+            <version>0.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.wxpay</groupId>
+            <artifactId>wxpay-sdk</artifactId>
+            <version>0.0.3</version>
+        </dependency>
+        <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
             <version>2.3.0</version>
@@ -64,6 +85,22 @@
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>1.7.36</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/cn/edu/guet/weappdemo/wxpay/config/WeiXinProperties.java
+++ b/src/main/java/cn/edu/guet/weappdemo/wxpay/config/WeiXinProperties.java
@@ -1,0 +1,25 @@
+package cn.edu.guet.weappdemo.wxpay.config;
+
+import cn.edu.guet.weappdemo.wxpay.utils.FileUtil;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Data
+@Configuration(proxyBeanMethods = false)
+@ConfigurationProperties(prefix = "wx.pay")
+@Primary //覆盖 当有多个这个的WxPayProperties实现类 注入这个
+public class WeiXinProperties {
+
+    /** appId ： 微信公众号或者小程序等的appid */
+    private String appId;
+    /** appSecret ： 应用密钥 */
+    private String appSecret;
+    /** mchId ： 微信支付商户号 */
+    private String mchId;
+    /** mchKey ： 微信支付商户密钥 */
+    private String mchKey;
+    /** mchKey ： 商户证书目录 */
+    private String keyPath = FileUtil.getResourcesPath()+ "refund_certificate/apiclient_cert.p12";
+}

--- a/src/main/java/cn/edu/guet/weappdemo/wxpay/config/WxConfiguration.java
+++ b/src/main/java/cn/edu/guet/weappdemo/wxpay/config/WxConfiguration.java
@@ -1,0 +1,73 @@
+package cn.edu.guet.weappdemo.wxpay.config;
+
+import cn.binarywang.wx.miniapp.api.WxMaService;
+import cn.binarywang.wx.miniapp.api.impl.WxMaServiceImpl;
+import cn.binarywang.wx.miniapp.config.WxMaConfig;
+import cn.binarywang.wx.miniapp.config.impl.WxMaDefaultConfigImpl;
+import com.github.binarywang.wxpay.config.WxPayConfig;
+import com.github.binarywang.wxpay.service.WxPayService;
+import com.github.binarywang.wxpay.service.impl.WxPayServiceImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+/*
+*
+* 支付配置
+*
+* */
+@Slf4j
+@Configuration
+@ConditionalOnClass(WxPayService.class)//引入WxPayService这个类 下面两个才会实例化
+@EnableConfigurationProperties(WeiXinProperties.class) //注入WxPayProperties类
+@RequiredArgsConstructor
+public class WxConfiguration {
+    private final WeiXinProperties properties;
+
+    /**
+     *  获取小程序WxMaService
+     *
+     */
+
+    @Bean
+    @ConditionalOnMissingBean
+    public WxMaService wxMaService(){
+
+        //实例这个 WxMaConfig
+        WxMaConfig wxMaConfig = new WxMaDefaultConfigImpl();
+        ((WxMaDefaultConfigImpl) wxMaConfig).setAppid(StringUtils.trimToNull(this.properties.getAppId()));
+        ((WxMaDefaultConfigImpl) wxMaConfig).setSecret(StringUtils.trimToNull(this.properties.getAppSecret()));
+        WxMaService wxMaService = new WxMaServiceImpl();
+        //设置配置文件
+        wxMaService.setWxMaConfig(wxMaConfig);
+        return wxMaService;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public WxPayService wxPayService() {
+
+        //实例payConfig 设置固定参数
+        WxPayConfig payConfig = new WxPayConfig();
+        payConfig.setAppId(StringUtils.trimToNull(this.properties.getAppId()));
+        payConfig.setMchId(StringUtils.trimToNull(this.properties.getMchId()));
+        payConfig.setMchKey(StringUtils.trimToNull(this.properties.getMchKey()));
+//        payConfig.setSubAppId(StringUtils.trimToNull(this.properties.getSubAppId()));
+//        payConfig.setSubMchId(StringUtils.trimToNull(this.properties.getSubMchId()));
+        payConfig.setKeyPath(StringUtils.trimToNull(this.properties.getKeyPath()));
+
+        // 可以指定是否使用沙箱环境
+        payConfig.setUseSandboxEnv(false);
+
+        WxPayService wxPayService = new WxPayServiceImpl();
+        wxPayService.setConfig(payConfig);
+        return wxPayService;
+    }
+
+}

--- a/src/main/java/cn/edu/guet/weappdemo/wxpay/config/WxPayConfiguration.java
+++ b/src/main/java/cn/edu/guet/weappdemo/wxpay/config/WxPayConfiguration.java
@@ -1,0 +1,46 @@
+package cn.edu.guet.weappdemo.wxpay.config;
+
+import com.github.binarywang.wxpay.config.WxPayConfig;
+import com.github.binarywang.wxpay.service.WxPayService;
+import com.github.binarywang.wxpay.service.impl.WxPayServiceImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+
+@Slf4j
+@Configuration
+@ConditionalOnClass(WxPayService.class)//引入WxPayService这个类 下面两个才会实例化
+@EnableConfigurationProperties(WeiXinProperties.class) //注入WxPayProperties类
+@RequiredArgsConstructor
+public class WxPayConfiguration {
+    private final WeiXinProperties properties;
+
+    @Bean
+    @ConditionalOnMissingBean
+    public WxPayService wxPayService() {
+
+        //实例payConfig 设置固定参数
+        WxPayConfig payConfig = new WxPayConfig();
+        payConfig.setAppId(StringUtils.trimToNull(this.properties.getAppId()));
+        payConfig.setMchId(StringUtils.trimToNull(this.properties.getMchId()));
+        payConfig.setMchKey(StringUtils.trimToNull(this.properties.getMchKey()));
+//        payConfig.setSubAppId(StringUtils.trimToNull(this.properties.getSubAppId()));
+//        payConfig.setSubMchId(StringUtils.trimToNull(this.properties.getSubMchId()));
+        payConfig.setKeyPath(StringUtils.trimToNull(this.properties.getKeyPath()));
+
+        // 可以指定是否使用沙箱环境
+        payConfig.setUseSandboxEnv(false);
+
+        WxPayService wxPayService = new WxPayServiceImpl();
+        wxPayService.setConfig(payConfig);
+        return wxPayService;
+    }
+
+}

--- a/src/main/java/cn/edu/guet/weappdemo/wxpay/controller/CallbackController.java
+++ b/src/main/java/cn/edu/guet/weappdemo/wxpay/controller/CallbackController.java
@@ -1,0 +1,83 @@
+package cn.edu.guet.weappdemo.wxpay.controller;
+
+import com.github.binarywang.wxpay.bean.notify.WxPayNotifyResponse;
+import com.github.binarywang.wxpay.bean.notify.WxPayOrderNotifyResult;
+import com.github.binarywang.wxpay.bean.notify.WxPayRefundNotifyResult;
+import com.github.binarywang.wxpay.bean.result.BaseWxPayResult;
+import com.github.binarywang.wxpay.service.WxPayService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+
+/**
+ * 微信回调接口微信回调接口
+ */
+@Slf4j
+@RestController
+@RequestMapping("/mini/callback")
+@RequiredArgsConstructor
+public class CallbackController {
+
+    private final WxPayService wxPayService;
+
+
+    /**
+     * 微信支付回调接口
+     * @param request
+     * @return
+     */
+    @RequestMapping(value = "/payNotify")
+    public String payNotify(HttpServletRequest request) {
+        try {
+            String xmlResult = IOUtils.toString(request.getInputStream(), request.getCharacterEncoding());
+            WxPayOrderNotifyResult notifyResult = wxPayService.parseOrderNotifyResult(xmlResult);
+            // 结果正确 outTradeNo
+            String orderId = notifyResult.getOutTradeNo();
+            String tradeNo = notifyResult.getTransactionId();
+            String totalFee = BaseWxPayResult.fenToYuan(notifyResult.getTotalFee());
+            //支付成功
+            if("SUCCESS".equals(notifyResult.getResultCode())) {
+                log.info("================>微信支付回调：订单号<{}>",orderId);
+                //自己处理订单的业务逻辑，需要判断订单是否已经支付过，否则可能会重复调用
+
+            }
+            return WxPayNotifyResponse.success("成功");
+        } catch (Exception e) {
+            log.error("微信回调结果异常,异常原因{}", e.getMessage());
+            return WxPayNotifyResponse.success("code:"+9999+"微信回调结果异常,异常原因:"+e.getMessage());
+        }
+    }
+
+    /**
+     * 微信退款回调接口
+     * @param request
+     * @return
+     */
+    @RequestMapping(value = "/refundNotify")
+    public String refundNotify(HttpServletRequest request) {
+        try {
+            String xmlResult = IOUtils.toString(request.getInputStream(), request.getCharacterEncoding());
+            WxPayRefundNotifyResult wxPayRefundNotifyResult = wxPayService.parseRefundNotifyResult(xmlResult);
+            String outTradeNo = wxPayRefundNotifyResult.getReqInfo().getOutTradeNo();
+            Integer refundFee = wxPayRefundNotifyResult.getReqInfo().getRefundFee();
+            String outRefundNo = wxPayRefundNotifyResult.getReqInfo().getOutRefundNo();
+
+            //退款成功
+            if("SUCCESS".equals(wxPayRefundNotifyResult.getReqInfo().getRefundStatus())) {
+
+
+
+            }
+            return WxPayNotifyResponse.success("成功");
+        } catch (Exception e) {
+            log.error("微信回调结果异常,异常原因{}", e.getMessage());
+            return WxPayNotifyResponse.success("code:"+9999+"微信回调结果异常,异常原因:"+e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/cn/edu/guet/weappdemo/wxpay/entity/WxEntPayEntity.java
+++ b/src/main/java/cn/edu/guet/weappdemo/wxpay/entity/WxEntPayEntity.java
@@ -1,0 +1,38 @@
+package cn.edu.guet.weappdemo.wxpay.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+/**
+ * 微信商家打款参数
+ */
+@Data
+@AllArgsConstructor
+@Builder
+public class WxEntPayEntity {
+
+    //用户openid
+    private String openId;
+
+    //订单号
+    private String partnerTradeNo;
+
+   //是否校验真实姓名
+    private final String checkName = "FORCE_CHECK";
+
+    //用户名
+    private String reUserName;
+
+    //金额
+    private BigDecimal amount;
+
+    //描述
+    private String description;
+
+    //ip
+    private String spbillCreateIp;
+
+}

--- a/src/main/java/cn/edu/guet/weappdemo/wxpay/entity/WxLoginEntity.java
+++ b/src/main/java/cn/edu/guet/weappdemo/wxpay/entity/WxLoginEntity.java
@@ -1,0 +1,43 @@
+package cn.edu.guet.weappdemo.wxpay.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 微信授权参数
+ */
+@Data
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+public class WxLoginEntity implements Serializable {
+
+    //用户登录凭证
+    private String code;
+
+    //加密用户数据
+    private String encryptedData;
+
+    //加密算法的初始向量
+    private String iv;
+
+    //昵称
+    private String nickName;
+
+    //头像
+    private String avatar;
+
+    //openid
+    private String openId;
+
+    //性别： 0：未知、1：男、2：女
+    private Integer gender;
+
+    //手机号
+    private String phoneNumber;
+}
+

--- a/src/main/java/cn/edu/guet/weappdemo/wxpay/entity/WxPayEntity.java
+++ b/src/main/java/cn/edu/guet/weappdemo/wxpay/entity/WxPayEntity.java
@@ -1,0 +1,37 @@
+package cn.edu.guet.weappdemo.wxpay.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * 微信支付参数
+ */
+@Data
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+public class WxPayEntity {
+
+    //用户openid
+    private String openId;
+
+    //商户订单号
+    private String orderNo;
+
+    //支付金额
+    private BigDecimal totalFee;
+
+    ///内容
+    private String body;
+
+    //ip
+    private String ip;
+
+    //code
+    private String code;
+
+}

--- a/src/main/java/cn/edu/guet/weappdemo/wxpay/entity/WxRefundEntity.java
+++ b/src/main/java/cn/edu/guet/weappdemo/wxpay/entity/WxRefundEntity.java
@@ -1,0 +1,29 @@
+package cn.edu.guet.weappdemo.wxpay.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+/**
+ * 微信退款参数
+ */
+@Data
+@AllArgsConstructor
+@Builder
+public class WxRefundEntity {
+
+    //退款订单号
+    private String outRefundNo;
+
+    //原支付订单号
+    private String orderNo;
+
+    //订单金额
+    private BigDecimal totalFee;
+
+    //退款金额
+    private BigDecimal refundFee;
+
+}

--- a/src/main/java/cn/edu/guet/weappdemo/wxpay/service/TyWxPayService.java
+++ b/src/main/java/cn/edu/guet/weappdemo/wxpay/service/TyWxPayService.java
@@ -1,0 +1,120 @@
+package cn.edu.guet.weappdemo.wxpay.service;
+
+import cn.edu.guet.weappdemo.wxpay.entity.WxEntPayEntity;
+import cn.edu.guet.weappdemo.wxpay.entity.WxPayEntity;
+import cn.edu.guet.weappdemo.wxpay.entity.WxRefundEntity;
+import cn.edu.guet.weappdemo.wxpay.utils.DateUtils;
+import com.github.binarywang.wxpay.bean.entpay.EntPayRequest;
+import com.github.binarywang.wxpay.bean.entpay.EntPayResult;
+import com.github.binarywang.wxpay.bean.request.BaseWxPayRequest;
+import com.github.binarywang.wxpay.bean.request.WxPayRefundRequest;
+import com.github.binarywang.wxpay.bean.request.WxPayUnifiedOrderRequest;
+import com.github.binarywang.wxpay.constant.WxPayConstants;
+import com.github.binarywang.wxpay.exception.WxPayException;
+import com.github.binarywang.wxpay.service.WxPayService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+/**
+ * @ClassName 公众号支付WxPayService
+ * @Author LWL
+ * @Date 2022-03-17
+ **/
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TyWxPayService {
+
+    private final WxPayService wxPayService;
+
+    public Object wxPay(WxPayEntity entity) {
+        /**
+         * 处理内部业务，校验订单等
+         */
+        final WxPayUnifiedOrderRequest wxPayUnifiedOrderRequest = WxPayUnifiedOrderRequest.newBuilder()
+                //调起支付的人的 openId
+                .openid(entity.getOpenId(/*这里写openid*/))/*这里写openid*/
+                //订单编号
+                .outTradeNo(entity.getOrderNo(/*自己生成的订单号*/))/*自己生成的订单号*/
+                //小程序支付
+                .tradeType(WxPayConstants.TradeType.JSAPI)
+                //订单金额(单位是分)BaseWxPayRequest.yuanToFen()这个方法是将元转分
+                .totalFee(BaseWxPayRequest.yuanToFen(entity.getTotalFee().toString()))//"这里写支付金额"
+                //商品描述
+                .body(entity.getBody(/*描述*/))/*描述*/
+                //获取本地IP
+                .spbillCreateIp(entity.getIp(/*客户端ip*/))/*客户端ip*/
+                //回调的 URL 地址
+                .notifyUrl("回调接口地址")/*这里写支付成功后微信的微信接口*/
+                .timeExpire(DateUtils.format(DateUtils.computeDate(LocalDateTime.now(/*支付过期时间*/), 10, DateUtils.Type.MINUTE), "yyyyMMddHHmmss"))//支付过期时间
+                .timeStart(DateUtils.dateTimeNow())//当前时间
+                .build();
+        wxPayUnifiedOrderRequest.setSignType(WxPayConstants.SignType.MD5);
+
+        Object order = null;
+        try {
+            order = wxPayService.createOrder(wxPayUnifiedOrderRequest);
+        } catch (WxPayException e) {
+            throw new RuntimeException(e.getErrCodeDes());
+        }
+        return order;
+    }
+
+    /**
+     * 退款
+     * @throws WxPayException
+     */
+    public void refundOrder(WxRefundEntity entity) {
+
+        WxPayRefundRequest wxPayRefundRequest = WxPayRefundRequest.newBuilder()
+                //订单总金额
+                .totalFee(BaseWxPayRequest.yuanToFen(entity.getTotalFee().toString()))
+                //订单编号
+                .outTradeNo(entity.getOrderNo())
+                //退款编号
+                .outRefundNo(entity.getOutRefundNo())
+                //退款金额
+                .refundFee(BaseWxPayRequest.yuanToFen(entity.getRefundFee().toString()))
+                //回调接口
+                .notifyUrl("回调接口地址")
+                .build();
+
+        try {
+            wxPayService.refund(wxPayRefundRequest);
+        } catch (WxPayException e) {
+            throw new RuntimeException(e.getErrCodeDes());
+        }
+    }
+    /**
+     * 企业打款
+     */
+    public EntPayResult entPay(WxEntPayEntity entity) {
+
+        EntPayRequest entPayRequest = EntPayRequest.newBuilder()
+                .openid(entity.getOpenId())
+                //商户订单号，需保持唯一性(只能是字母或者数字，不能包含有其它字符)
+                .partnerTradeNo(entity.getPartnerTradeNo())
+                //是否检验真实姓名  NO_CHECK：不校验真实姓名 FORCE_CHECK：强校验真实姓名
+                .checkName(entity.getCheckName())
+                //收款用户真实姓名。如果check_name设置为FORCE_CHECK，则必填用户真实姓名 如需电子回单，需要传入收款用户姓名
+                .reUserName(entity.getReUserName())
+                //转账金额，单位为分
+                .amount(BaseWxPayRequest.yuanToFen(entity.getAmount().toString()))
+                //付款备注，必填。注意：备注中的敏感词会被转成字符*
+                .description(entity.getDescription())
+                //该IP同在商户平台设置的IP白名单中的IP没有关联，该IP可传用户端或者服务端的IP。
+                .spbillCreateIp(entity.getSpbillCreateIp())
+                .build();
+
+        try {
+            return wxPayService.getEntPayService().entPay(entPayRequest);
+        } catch (WxPayException e) {
+            throw new RuntimeException(e.getErrCodeDes());
+        }
+    }
+
+}

--- a/src/main/java/cn/edu/guet/weappdemo/wxpay/service/WxAuthService.java
+++ b/src/main/java/cn/edu/guet/weappdemo/wxpay/service/WxAuthService.java
@@ -1,0 +1,55 @@
+package cn.edu.guet.weappdemo.wxpay.service;
+
+import cn.binarywang.wx.miniapp.api.WxMaService;
+import cn.binarywang.wx.miniapp.bean.WxMaJscode2SessionResult;
+import cn.binarywang.wx.miniapp.bean.WxMaPhoneNumberInfo;
+import cn.edu.guet.weappdemo.wxpay.entity.WxLoginEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.chanjar.weixin.common.error.WxErrorException;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WxAuthService {
+
+    private final WxMaService wxMaService;
+
+
+    /**
+     *  微信授权获取用户信息
+     * @param entity
+     * @return
+     * @throws WxErrorException
+     */
+    public WxLoginEntity wxAuth(WxLoginEntity entity) throws WxErrorException {
+
+        // 获取微信用户session
+        WxMaJscode2SessionResult session = wxMaService.getUserService().getSessionInfo(entity.getCode());
+        Assert.isNull(session,"获取微信Session失败");
+        Assert.isNull(session.getOpenid(),"获取openid失败");
+
+
+        // 解密手机号码信息
+        WxMaPhoneNumberInfo wxMaPhoneNumberInfo = wxMaService.getUserService().getPhoneNoInfo(session.getSessionKey(),
+                entity.getEncryptedData(), entity.getIv());
+        if (wxMaPhoneNumberInfo == null || StringUtils.isEmpty(wxMaPhoneNumberInfo.getPhoneNumber())){
+            throw new RuntimeException("获取用户手机号失败");
+        }
+        log.info(String.format("============用户登录注册获取微信用户信息===========> openId=%s, nickName=%s,phone=%s", session.getOpenid(), entity.getNickName(),wxMaPhoneNumberInfo.getPhoneNumber()));
+        //封装返回用户信息
+        WxLoginEntity wxLoginEntity = WxLoginEntity.builder()
+                .avatar(entity.getAvatar())
+                .nickName(entity.getNickName())
+                .openId(session.getOpenid())
+                .gender(0)
+                .phoneNumber(wxMaPhoneNumberInfo.getPhoneNumber())
+                .build();
+
+        return wxLoginEntity;
+    }
+
+}

--- a/src/main/java/cn/edu/guet/weappdemo/wxpay/utils/DateUtils.java
+++ b/src/main/java/cn/edu/guet/weappdemo/wxpay/utils/DateUtils.java
@@ -1,0 +1,225 @@
+package cn.edu.guet.weappdemo.wxpay.utils;
+
+import org.apache.commons.lang3.time.DateFormatUtils;
+
+import java.lang.management.ManagementFactory;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+/**
+ * 时间工具类
+ */
+public class DateUtils extends org.apache.commons.lang3.time.DateUtils {
+    public static String YYYY = "yyyy";
+
+    public static String YYYY_MM = "yyyy-MM";
+
+    public static String YYYY_MM_DD = "yyyy-MM-dd";
+
+    public static String YYYYMMDDHHMMSS = "yyyyMMddHHmmss";
+
+    public static String YYYY_MM_DD_HH_MM_SS = "yyyy-MM-dd HH:mm:ss";
+
+    public static String YYYY_MM_DD_HH_MM = "yyyy年MM月dd日 HH:mm";
+
+    private static String[] parsePatterns = {
+            "yyyy-MM-dd", "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd HH:mm", "yyyy-MM",
+            "yyyy/MM/dd", "yyyy/MM/dd HH:mm:ss", "yyyy/MM/dd HH:mm", "yyyy/MM",
+            "yyyy.MM.dd", "yyyy.MM.dd HH:mm:ss", "yyyy.MM.dd HH:mm", "yyyy.MM"};
+
+    /**
+     * 获取当前Date型日期
+     *
+     * @return Date() 当前日期
+     */
+    public static Date getNowDate() {
+        return new Date();
+    }
+
+    /**
+     * 获取当前日期, 默认格式为yyyy-MM-dd
+     *
+     * @return String
+     */
+    public static String getDate() {
+        return dateTimeNow(YYYY_MM_DD);
+    }
+
+    public static final String getTime() {
+        return dateTimeNow(YYYY_MM_DD_HH_MM_SS);
+    }
+
+    public static final String dateTimeNow() {
+        return dateTimeNow(YYYYMMDDHHMMSS);
+    }
+
+    public static final String dateTimeNow(final String format) {
+        return parseDateToStr(format, new Date());
+    }
+
+    public static final String dateTime(final Date date) {
+        return parseDateToStr(YYYY_MM_DD, date);
+    }
+
+    public static final String parseDateToStr(final String format, final Date date) {
+        return new SimpleDateFormat(format).format(date);
+    }
+
+    public static final Date dateTime(final String format, final String ts) {
+        try {
+            return new SimpleDateFormat(format).parse(ts);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 日期路径 即年/月/日 如2018/08/08
+     */
+    public static final String datePath() {
+        Date now = new Date();
+        return DateFormatUtils.format(now, "yyyy/MM/dd");
+    }
+
+    /**
+     * 日期路径 即年/月/日 如20180808
+     */
+    public static final String dateTime() {
+        Date now = new Date();
+        return DateFormatUtils.format(now, "yyyyMMdd");
+    }
+
+    /**
+     * 日期型字符串转化为日期 格式
+     */
+    public static Date parseDate(Object str) {
+        if (str == null) {
+            return null;
+        }
+        try {
+            return parseDate(str.toString(), parsePatterns);
+        } catch (ParseException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 获取服务器启动时间
+     */
+    public static Date getServerStartDate() {
+        long time = ManagementFactory.getRuntimeMXBean().getStartTime();
+        return new Date(time);
+    }
+
+    /**
+     * 计算两个时间差
+     */
+    public static String getDatePoor(Date endDate, Date nowDate) {
+        long nd = 1000 * 24 * 60 * 60;
+        long nh = 1000 * 60 * 60;
+        long nm = 1000 * 60;
+        // long ns = 1000;
+        // 获得两个时间的毫秒时间差异
+        long diff = endDate.getTime() - nowDate.getTime();
+        // 计算差多少天
+        long day = diff / nd;
+        // 计算差多少小时
+        long hour = diff % nd / nh;
+        // 计算差多少分钟
+        long min = diff % nd % nh / nm;
+        // 计算差多少秒//输出结果
+        // long sec = diff % nd % nh % nm / ns;
+        return day + "天" + hour + "小时" + min + "分钟";
+    }
+    //计算两个时间相差多少秒
+    public static long getDatePoor(LocalDateTime startDate, LocalDateTime endDate) {
+        long start = startDate.toEpochSecond(ZoneOffset.of("+8"));
+        long end = endDate.toEpochSecond(ZoneOffset.of("+8"));
+        return end - start;
+    }
+    public static String format(LocalDateTime localDateTime,String format){
+        return DateTimeFormatter.ofPattern(format).format(localDateTime);
+    }
+    public static LocalDateTime parse(String dateTime,String format){
+        return LocalDateTime.parse(dateTime,DateTimeFormatter.ofPattern(format));
+    }
+    public static String format(LocalDateTime localDateTime){
+        return format(localDateTime,YYYY_MM_DD_HH_MM_SS);
+    }
+
+    /**
+     * 计算时间
+     * @param date
+     * @param time
+     * @param type
+     * @return
+     */
+    public static LocalDateTime computeDate(LocalDateTime date,long time,Type type){
+        LocalDateTime newDate = null;
+        switch (type){
+            case YEAR:
+                newDate = time>0?date.plusYears(time):date.minusYears(Math.abs(time));
+                break;
+            case MONTH:
+                newDate = time>0?date.plusMonths(time):date.minusMonths(Math.abs(time));
+                break;
+            case WEEK:
+                newDate = time>0?date.plusWeeks(time):date.minusWeeks(Math.abs(time));
+                break;
+            case DAY:
+                newDate = time>0?date.plusDays(time):date.minusDays(Math.abs(time));
+                break;
+            case HOUR:
+                newDate = time>0?date.plusHours(time):date.minusHours(Math.abs(time));
+                break;
+            case MINUTE:
+                newDate = time>0?date.plusMinutes(time):date.minusMinutes(Math.abs(time));
+                break;
+            case SECOND:
+                newDate = time>0?date.plusSeconds(time):date.minusSeconds(Math.abs(time));
+                break;
+            case NANO:
+                newDate = time>0?date.plusNanos(time):date.minusNanos(Math.abs(time));
+                break;
+        }
+        return newDate;
+    }
+            public enum Type{
+        YEAR,
+        MONTH,
+        WEEK,
+        DAY,
+        HOUR,
+        MINUTE,
+        SECOND,
+        NANO;
+    }
+
+    /**
+     * 比较两日期大小
+     *
+     * @param date      日期
+     * @param otherDate 另一个日期
+     * @return 比较两日期大小。如果date>otherDate则返回true,否则false
+     */
+    public static Boolean compare(Date date, Date otherDate) {
+        return date.getTime() > otherDate.getTime();
+    }
+    public static Boolean compare(LocalDateTime date, LocalDateTime otherDate) {
+        long time1 = date.toInstant(ZoneOffset.ofHours(8)).toEpochMilli();
+        long time2 = otherDate.toInstant(ZoneOffset.ofHours(8)).toEpochMilli();
+        return time1 > time2;
+    }
+
+    public static void main(String[] args) {
+        LocalDateTime time = computeDate(LocalDateTime.now(), 10, Type.MINUTE);
+
+        System.out.println(format(time,YYYY_MM_DD_HH_MM_SS));
+        System.out.println(DateUtils.getTime());
+    }
+
+}

--- a/src/main/java/cn/edu/guet/weappdemo/wxpay/utils/FileUtil.java
+++ b/src/main/java/cn/edu/guet/weappdemo/wxpay/utils/FileUtil.java
@@ -1,0 +1,23 @@
+package cn.edu.guet.weappdemo.wxpay.utils;
+
+import java.io.*;
+import java.net.URLDecoder;
+
+/**
+ * File工具类，扩展 hutool 工具包
+ */
+public class FileUtil {
+    /**
+     * {@code description: 获取资源文件绝对路径,文件在项目下}
+     */
+    public static String getResourcesPath() {
+        String classFilePath = FileUtil.class.getResource("/").getPath();
+        try {
+            classFilePath = URLDecoder.decode(classFilePath, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        return classFilePath;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,3 +11,16 @@ server:
 mybatis:
   mapper-locations: classpath:mapper/*Mapper.xml
   type-aliases-package: cn.edu.guet.weappdemo.mapper
+
+
+#微信配置
+wx:
+  pay:
+    #微信公众号或者小程序等的appid
+    app-id: wx0ce552912c5e4957
+    #应用密钥
+    app-secret: 1904646f9533ce1993c86e3ad302f504
+    #微信支付商户号
+    mch-id: 1623889015
+    #微信支付商户密钥
+    mch-key: v2LZk95bXz6VPjQq9yOPg3wPCD3BKqcM


### PR DESCRIPTION
…1/article/details/124491929）

1、CallbackController文件为支付回调接口（payNotify）和退款回调接口（refundNotify）
2、WxPayConfiguration为支付配置文件，需要AppId（小程序id），MchId（商户Id，老师的Id），MchKey（商户秘钥，老师的秘钥），KeyPath（商户证书目录）
3、TyWxPayServie为支付退款类，前端直接调用，wxPay方法为小程序支付方法，refundOrder为退款方法，entPay为企业打款，即提现方法
4、WxAuthService为微信获取用户信息类，前端使用wx.request，和wx.getUserProfile方法获取code和用户信息。